### PR TITLE
Fix delete bugs

### DIFF
--- a/core/db.go
+++ b/core/db.go
@@ -81,6 +81,7 @@ func Open(dir string, opts ...Option) (rdb *DB, rerr error) {
 		//  should i enforce the listen somehow, or drop errors?
 		mergeErr:     make(chan error, 1),
 		onMergeStart: func() {},
+		onMergeApply: func() {},
 		// default values
 		fsync:             false,
 		rolloverThreshold: 1 * 1024 * 1024,

--- a/core/db.go
+++ b/core/db.go
@@ -63,6 +63,12 @@ func WithOnMergeStart(f func()) Option {
 	}
 }
 
+func WithOnMergeApply(f func()) Option {
+	return func(db *DB) {
+		db.onMergeApply = f
+	}
+}
+
 type Option func(*DB)
 
 func Open(dir string, opts ...Option) (rdb *DB, rerr error) {

--- a/core/merge.go
+++ b/core/merge.go
@@ -7,14 +7,14 @@ import (
 )
 
 type mergeOutput struct {
-	segments []*segment
-	index    map[string]*recordLocation
+	segments     []*segment
+	indexChanges map[string][2]*recordLocation
 }
 
 func newMergeOutput() *mergeOutput {
 	return &mergeOutput{
-		segments: make([]*segment, 0),
-		index:    make(map[string]*recordLocation),
+		segments:     make([]*segment, 0),
+		indexChanges: make(map[string][2]*recordLocation),
 	}
 }
 
@@ -89,12 +89,14 @@ func (db *DB) merge() (rerr error) {
 			loc, ok := db.index[rec.key]
 			db.rw.RUnlock()
 
-			// key is deleted, skip it
+			// db.index is guaranteed to be in a more recent state
+			// than `toMerge` segments. so if `key` doesn't exist
+			// in db.index, we can safely skip this record
 			if !ok {
 				continue
 			}
 
-			// we will include latest occurrence the record
+			// we will include latest occurrence of the record
 			// in the new segment and update the merge index
 			isLatest := loc.seg == seg && loc.offset == rec.off
 
@@ -117,11 +119,13 @@ func (db *DB) merge() (rerr error) {
 				return err
 			}
 
-			// update the mergeIndex
-			out.index[rec.key] = &recordLocation{
+			// we memorize the both the old and the new location of the record
+			// while merging to index, we need to make sure we're not replacing
+			// a newer value of the key (explained below)
+			out.indexChanges[rec.key] = [2]*recordLocation{loc, {
 				seg:    mergeSeg,
 				offset: off,
-			}
+			}}
 		}
 
 		if err = rs.err; err != nil {
@@ -138,6 +142,8 @@ func (db *DB) merge() (rerr error) {
 		}
 	}
 
+	db.onMergeApply()
+
 	// overwrite segments and index with one lock,
 	// otherwise one will have stale data.
 	db.rw.Lock()
@@ -147,9 +153,32 @@ func (db *DB) merge() (rerr error) {
 	// and un-merged segments are appended
 	db.segments = append(out.segments, db.segments[inputLen:]...)
 
-	// overwrite with merged entries
-	for k, loc := range out.index {
-		db.index[k] = loc
+	// overwrite index with merged entries
+	// however, we should be careful about the updated keys
+	// key may have been overwritten/deleted in the db
+	// while we're busy with creating merge segments,
+	// in that case we skip updating the key
+	for key, locs := range out.indexChanges {
+		curLoc, ok := db.index[key]
+		if !ok {
+			// deleted on db, skip
+			continue
+		}
+
+		// if a new location for the record exists, it means this key
+		// have been updated with a new value outside the merge process
+		// we only update the index if this is the most recent location
+		locBefore := locs[0] // to be replaced
+		locAfter := locs[1]  // possible replacer
+
+		isLatest := locBefore.seg == curLoc.seg && locBefore.offset == curLoc.offset
+		if !isLatest {
+			continue
+		}
+
+		// most recent. replace!
+		db.index[key] = locAfter
+
 	}
 
 	if err := db.overwriteManifest(); err != nil {

--- a/core/segment.go
+++ b/core/segment.go
@@ -190,6 +190,7 @@ func (rs *recordScanner) scan() bool {
 	}
 	keyLen := int(binary.LittleEndian.Uint32(hdr[0:4]))
 	valLen := int(binary.LittleEndian.Uint32(hdr[4:8]))
+	wt := WriteType(hdr[8])
 
 	// read the key payload
 	keyBytes := make([]byte, keyLen)


### PR DESCRIPTION
I noticed two bugs related to delete
1. DB.Open() keeping removed records in the index
2. DB.merge() overwriting recent keys with stale keys

Comments explain the issues clearly. Fixed the bugs and added tests for both scenarios