### PR TITLE
Add IO test script

### DIFF
--- a/iotest.go
+++ b/iotest.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	mode     = flag.String("mode", "seq", "seq | rand | mix-shared | mix-split")
+	filePath = flag.String("file", "segment.dat", "file to read")
+	duration = flag.Duration("dur", 15*time.Second, "run time")
+	seqBS    = flag.Int64("seqbs", 1<<20, "sequential block size (bytes)")
+	randBS   = flag.Int64("randbs", 4<<10, "random block size (bytes)")
+	randRate = flag.Int("randrate", 0, "limit random reads per second (0 = unlimited)")
+	randSeed = flag.Int64("seed", time.Now().UnixNano(), "PRNG seed")
+)
+
+func main() {
+	flag.Parse()
+
+	info, err := os.Stat(*filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stat: %v\n", err)
+		os.Exit(1)
+	}
+	fileSize := info.Size()
+
+	switch *mode {
+	case "seq":
+		runSeq(fileSize)
+	case "rand":
+		runRand(fileSize)
+	case "mix-shared":
+		runMixed(fileSize, false)
+	case "mix-split":
+		runMixed(fileSize, true)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown mode %q\n", *mode)
+		os.Exit(1)
+	}
+}
+
+// ---------------- one-shot helpers ----------------
+
+func openRO(path string) *os.File {
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open: %v\n", err)
+		os.Exit(1)
+	}
+	return f
+}
+
+func mib(b int64, d time.Duration) float64 {
+	return float64(b) / (1024 * 1024) / d.Seconds()
+}
+
+// ---------------- pure sequential ----------------
+
+func runSeq(fileSize int64) {
+	f := openRO(*filePath)
+	defer f.Close() // nolint:errcheck
+
+	buf := make([]byte, *seqBS)
+	deadline := time.Now().Add(*duration)
+	var reads int64
+
+	for time.Now().Before(deadline) {
+		for off := int64(0); off < fileSize && time.Now().Before(deadline); off += *seqBS {
+			if _, err := f.ReadAt(buf, off); err != nil {
+				fmt.Fprintf(os.Stderr, "seq read: %v\n", err)
+				os.Exit(1)
+			}
+			reads++
+		}
+	}
+
+	total := reads * *seqBS
+	fmt.Printf("Sequential: %.2f MiB/s (%d reads)\n", mib(total, *duration), reads)
+}
+
+// ---------------- pure random ----------------
+
+func runRand(fileSize int64) {
+	f := openRO(*filePath)
+	defer f.Close() // nolint:errcheck
+
+	buf := make([]byte, *randBS)
+	r := rand.New(rand.NewSource(*randSeed))
+	deadline := time.Now().Add(*duration)
+	var reads int64
+
+	// optional throttling
+	var ticker *time.Ticker
+	if *randRate > 0 {
+		ticker = time.NewTicker(time.Second / time.Duration(*randRate))
+		defer ticker.Stop()
+	}
+
+	for time.Now().Before(deadline) {
+		if ticker != nil {
+			<-ticker.C
+		}
+		off := r.Int63n(fileSize - *randBS)
+		if _, err := f.ReadAt(buf, off); err != nil {
+			fmt.Fprintf(os.Stderr, "rand read: %v\n", err)
+			os.Exit(1)
+		}
+		reads++
+	}
+
+	total := reads * *randBS
+	fmt.Printf("Random: %.2f MiB/s (%d reads)\n", mib(total, *duration), reads)
+}
+
+// ---------------- mixed ----------------
+
+func runMixed(fileSize int64, splitFD bool) {
+	seqF := openRO(*filePath)
+	defer seqF.Close() // nolint:errcheck
+	rndF := seqF
+	if splitFD {
+		rndF = openRO(*filePath) // second descriptor
+		defer rndF.Close() // nolint:errcheck
+	}
+
+	var seqBytes, rndBytes int64
+	deadline := time.Now().Add(*duration)
+	r := rand.New(rand.NewSource(*randSeed))
+	var wg sync.WaitGroup
+
+	// sequential goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, *seqBS)
+		for time.Now().Before(deadline) {
+			for off := int64(0); off < fileSize && time.Now().Before(deadline); off += *seqBS {
+				if _, err := seqF.ReadAt(buf, off); err != nil {
+					fmt.Fprintf(os.Stderr, "seq read: %v\n", err)
+					os.Exit(1)
+				}
+				atomic.AddInt64(&seqBytes, *seqBS)
+			}
+		}
+	}()
+
+	// optional throttle
+	var ticker *time.Ticker
+	if *randRate > 0 {
+		ticker = time.NewTicker(time.Second / time.Duration(*randRate))
+		defer ticker.Stop()
+	}
+
+	// random goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, *randBS)
+		for time.Now().Before(deadline) {
+			if ticker != nil {
+				<-ticker.C
+			}
+			off := r.Int63n(fileSize - *randBS)
+			if _, err := rndF.ReadAt(buf, off); err != nil {
+				fmt.Fprintf(os.Stderr, "rand read: %v\n", err)
+				os.Exit(1)
+			}
+			atomic.AddInt64(&rndBytes, *randBS)
+		}
+	}()
+
+	wg.Wait()
+
+	fmt.Printf("%s: Seq %.2f MiB/s  Rand %.2f MiB/s\n",
+		map[bool]string{false: "Mixed-shared", true: "Mixed-split"}[splitFD],
+		mib(seqBytes, *duration),
+		mib(rndBytes, *duration),
+	)
+}
+

--- a/run_iotests.sh
+++ b/run_iotests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(pwd)"           # assumed to be bitdb working directory
+FILE="../segment.dat"  # adjust if needed
+RANDRATE=10000
+SEQBS_SMALL=32768      # 32 KiB
+RANDBS_SMALL=4096      # 4 KiB
+
+echo "=== DEFAULT BLOCK SIZES (1 MiB seq, 4 KiB rand) ==="
+for i in $(seq 1 10); do
+  echo
+  echo "--- Run #$i (shared-FD) ---"
+  go run iotest.go -mode=mix-shared -file="${FILE}" -randrate="${RANDRATE}"
+
+  echo "--- Run #$i (split-FD) ---"
+  go run iotest.go -mode=mix-split  -file="${FILE}" -randrate="${RANDRATE}"
+done
+
+echo
+echo "=== SMALL BLOCKS (32 KiB seq, 4 KiB rand) ==="
+for i in $(seq 1 10); do
+  echo
+  echo "--- Run #$i (shared-FD) ---"
+  go run iotest.go -mode=mix-shared -file="${FILE}" \
+      -seqbs="${SEQBS_SMALL}" -randbs="${RANDBS_SMALL}" -randrate="${RANDRATE}"
+
+  echo "--- Run #$i (split-FD) ---"
+  go run iotest.go -mode=mix-split  -file="${FILE}" \
+      -seqbs="${SEQBS_SMALL}" -randbs="${RANDBS_SMALL}" -randrate="${RANDRATE}"
+done
+
+echo
+echo "All tests complete."
+


### PR DESCRIPTION
I noticed I'm using readAt with the same FD on both my sequential scan and random gets(merge scan uses readAt by SectionReader.read -> File.ReadAt)

In this case, I was wondering how OS behaves regarding readahead prefetching. Chatgpt told me that linux tracks readahead heuristics in a per-FD `file_ra_state`, [ref](https://docs.kernel.org/filesystems/api-summary.html#c.file). So random gets will actually mess with readahead for sequential reads. 

To prove it, we prepped a nice script that interleaves random reads with sequential scans on shared vs separate FDs. There is a slight(5-10%) difference, so I know there's a difference. Gonna have separate file handles for seq reads and random gets from now on. Keeping this script around for future needs.

Also cgpt suggested fio, I think I can't do the same test with it because it always uses separate FDs per task. But keeping the script in case I need it:
```
# in one terminal or background job:
fio --name=rand_get --filename=~/segment.dat --ioengine=libaio --direct=1 \
    --rw=randread --bs=4k --iodepth=1 --size=1G --runtime=15 --time_based &

# then immediately in another terminal (or same shell):
fio --name=merge_scan --filename=~/segment.dat --ioengine=libaio --direct=1 \
    --rw=read --bs=1M --iodepth=1 --size=1G --runtime=15 --time_based
```


Test results:
```
$ ./run_iotests.sh
=== DEFAULT BLOCK SIZES (1 MiB seq, 4 KiB rand) ===

--- Run #1 (shared-FD) ---
Mixed-shared: Seq 924.07 MiB/s  Rand 6.08 MiB/s
--- Run #1 (split-FD) ---
Mixed-split: Seq 963.53 MiB/s  Rand 5.51 MiB/s

--- Run #2 (shared-FD) ---
Mixed-shared: Seq 934.67 MiB/s  Rand 5.93 MiB/s
--- Run #2 (split-FD) ---
Mixed-split: Seq 956.60 MiB/s  Rand 6.20 MiB/s

--- Run #3 (shared-FD) ---
Mixed-shared: Seq 823.40 MiB/s  Rand 5.65 MiB/s
--- Run #3 (split-FD) ---
Mixed-split: Seq 875.40 MiB/s  Rand 5.70 MiB/s

--- Run #4 (shared-FD) ---
Mixed-shared: Seq 913.13 MiB/s  Rand 5.34 MiB/s
--- Run #4 (split-FD) ---
Mixed-split: Seq 907.80 MiB/s  Rand 5.84 MiB/s

--- Run #5 (shared-FD) ---
Mixed-shared: Seq 857.27 MiB/s  Rand 5.34 MiB/s
--- Run #5 (split-FD) ---
Mixed-split: Seq 926.40 MiB/s  Rand 5.73 MiB/s

--- Run #6 (shared-FD) ---
Mixed-shared: Seq 934.80 MiB/s  Rand 5.89 MiB/s
--- Run #6 (split-FD) ---
Mixed-split: Seq 904.73 MiB/s  Rand 5.90 MiB/s

--- Run #7 (shared-FD) ---
Mixed-shared: Seq 825.93 MiB/s  Rand 6.54 MiB/s
--- Run #7 (split-FD) ---
Mixed-split: Seq 904.33 MiB/s  Rand 5.66 MiB/s

--- Run #8 (shared-FD) ---
Mixed-shared: Seq 777.33 MiB/s  Rand 7.14 MiB/s
--- Run #8 (split-FD) ---
Mixed-split: Seq 939.93 MiB/s  Rand 5.93 MiB/s

--- Run #9 (shared-FD) ---
Mixed-shared: Seq 837.53 MiB/s  Rand 6.13 MiB/s
--- Run #9 (split-FD) ---
Mixed-split: Seq 912.33 MiB/s  Rand 5.67 MiB/s

--- Run #10 (shared-FD) ---
Mixed-shared: Seq 769.53 MiB/s  Rand 6.33 MiB/s
--- Run #10 (split-FD) ---
Mixed-split: Seq 933.27 MiB/s  Rand 5.79 MiB/s

=== SMALL BLOCKS (32 KiB seq, 4 KiB rand) ===

--- Run #1 (shared-FD) ---
Mixed-shared: Seq 348.01 MiB/s  Rand 8.02 MiB/s
--- Run #1 (split-FD) ---
Mixed-split: Seq 372.63 MiB/s  Rand 9.29 MiB/s

--- Run #2 (shared-FD) ---
Mixed-shared: Seq 380.62 MiB/s  Rand 9.28 MiB/s
--- Run #2 (split-FD) ---
Mixed-split: Seq 352.89 MiB/s  Rand 9.14 MiB/s

--- Run #3 (shared-FD) ---
Mixed-shared: Seq 369.12 MiB/s  Rand 8.88 MiB/s
--- Run #3 (split-FD) ---
Mixed-split: Seq 358.84 MiB/s  Rand 9.14 MiB/s

--- Run #4 (shared-FD) ---
Mixed-shared: Seq 380.31 MiB/s  Rand 9.30 MiB/s
--- Run #4 (split-FD) ---
Mixed-split: Seq 383.75 MiB/s  Rand 9.51 MiB/s

--- Run #5 (shared-FD) ---
Mixed-shared: Seq 355.18 MiB/s  Rand 9.44 MiB/s
--- Run #5 (split-FD) ---
Mixed-split: Seq 352.70 MiB/s  Rand 8.97 MiB/s

--- Run #6 (shared-FD) ---
Mixed-shared: Seq 352.07 MiB/s  Rand 9.29 MiB/s
--- Run #6 (split-FD) ---
Mixed-split: Seq 384.69 MiB/s  Rand 9.46 MiB/s

--- Run #7 (shared-FD) ---
Mixed-shared: Seq 373.66 MiB/s  Rand 9.43 MiB/s
--- Run #7 (split-FD) ---
Mixed-split: Seq 387.14 MiB/s  Rand 9.30 MiB/s

--- Run #8 (shared-FD) ---
Mixed-shared: Seq 376.14 MiB/s  Rand 9.23 MiB/s
--- Run #8 (split-FD) ---
Mixed-split: Seq 397.35 MiB/s  Rand 10.11 MiB/s

--- Run #9 (shared-FD) ---
Mixed-shared: Seq 380.45 MiB/s  Rand 9.38 MiB/s
--- Run #9 (split-FD) ---
Mixed-split: Seq 386.50 MiB/s  Rand 9.65 MiB/s

--- Run #10 (shared-FD) ---
Mixed-shared: Seq 382.03 MiB/s  Rand 9.40 MiB/s
--- Run #10 (split-FD) ---
Mixed-split: Seq 364.08 MiB/s  Rand 9.48 MiB/s

All tests complete.
```